### PR TITLE
多gpu训练，beam search

### DIFF
--- a/crslab/config/config.py
+++ b/crslab/config/config.py
@@ -36,6 +36,10 @@ class Config:
         self.opt = self.load_yaml_configs(config_file)
         # gpu
         os.environ['CUDA_VISIBLE_DEVICES'] = gpu
+        gpu = gpu.split(",")
+        for i in range(len(gpu)):
+            gpu[i] = int(gpu[i])
+        self.opt["gpu"] = gpu
         # dataset
         dataset = self.opt['dataset']
         tokenize = self.opt['tokenize']

--- a/crslab/model/__init__.py
+++ b/crslab/model/__init__.py
@@ -45,6 +45,9 @@ def get_model(config, model_name, device, vocab, side_data=None):
         if config.opt["gpu"] == [-1]:
             return model
         else:
+            if len(config.opt["gpu"]) > 1 and model_name == 'PMI':
+                logger.info(f'[PMI model does not support multi GPUs yet, using single GPU now]')
+                return model.to(device)
             return torch.nn.DataParallel(model, device_ids=config["gpu"])
 
     else:

--- a/crslab/model/__init__.py
+++ b/crslab/model/__init__.py
@@ -8,6 +8,7 @@
 # @Email  : francis_kun_zhou@163.com, wxl1999@foxmail.com
 
 from loguru import logger
+import torch
 
 from .conversation import *
 from .crs import *
@@ -41,6 +42,10 @@ def get_model(config, model_name, device, vocab, side_data=None):
     if model_name in Model_register_table:
         model = Model_register_table[model_name](config, device, vocab, side_data)
         logger.info(f'[Build model {model_name}]')
-        return model
+        if config.opt["gpu"] == [-1]:
+            return model
+        else:
+            return torch.nn.DataParallel(model, device_ids=config["gpu"])
+
     else:
         raise NotImplementedError('Model [{}] has not been implemented'.format(model_name))

--- a/crslab/model/conversation/transformer/transformer.py
+++ b/crslab/model/conversation/transformer/transformer.py
@@ -190,7 +190,59 @@ class TransformerModel(BaseModel):
         logits = torch.cat(logits, dim=1)
         return logits, inputs
 
-    def converse(self, batch, mode):
+    def _decode_beam_search_with_kg(self, token_encoding, beam=4):
+        batch_size = token_encoding[0].shape[0]
+        xs = self._starts(batch_size).long().reshape(1, batch_size, -1)
+        incr_state = None
+        sequences = [[[list(), list(), 1.0]]] * batch_size
+        for i in range(self.longest_label):
+            # at beginning there is 1 candidate, when i!=0 there are 4 candidates
+            if i != 0:
+                xs = []
+                for d in range(len(sequences[0])):
+                    for j in range(batch_size):
+                        text = sequences[j][d][0]
+                        xs.append(text)
+                xs = torch.stack(xs).reshape(beam, batch_size, -1)  # (beam, batch_size, _)
+
+            logits_list = []
+            for x in xs:
+                dialog_latent, incr_state = self.conv_decoder(x, token_encoding, incr_state)
+                dialog_latent = dialog_latent[:, -1:, :]  # (bs, 1, dim)
+                gen_logits = F.linear(dialog_latent, self.token_embedding.weight)
+                logits_list.append(gen_logits)
+
+            logits = torch.stack(logits_list)
+            # turn into probabilities,in case of negative numbers
+            probs, preds = torch.nn.functional.softmax(logits).topk(beam, dim=-1)
+
+            # (candeidate, bs, 1 , beam) during first loop, candidate=1, otherwise candidate=beam
+
+            for j in range(batch_size):
+                all_candidates = []
+                for n in range(len(sequences[j])):
+                    for k in range(beam):
+                        prob = sequences[j][n][2]
+                        logit = sequences[j][n][1]
+                        if logit == []:
+                            logit_tmp = logits[n][j][0].unsqueeze(0)
+                        else:
+                            logit_tmp = torch.cat((logit, logits[n][j][0].unsqueeze(0)), dim=0)
+                        seq_tmp = torch.cat((xs[n][j].reshape(-1), preds[n][j][0][k].reshape(-1)))
+                        candidate = [seq_tmp, logit_tmp, prob * probs[n][j][0][k]]
+                        all_candidates.append(candidate)
+                ordered = sorted(all_candidates, key=lambda tup: tup[2], reverse=True)
+                sequences[j] = ordered[:beam]
+
+            # check if everyone has generated an end token
+            all_finished = ((xs == self.end_token_idx).sum(dim=1) > 0).sum().item() == batch_size
+            if all_finished:
+                break
+        logits = torch.stack([seq[0][1] for seq in sequences])
+        xs = torch.stack([seq[0][0] for seq in sequences])
+        return logits, xs
+
+    def forward(self, batch, mode):
         context_tokens, context_entities, context_words, response = batch
 
         # encoder-decoder

--- a/crslab/model/crs/kbrd/kbrd.py
+++ b/crslab/model/crs/kbrd/kbrd.py
@@ -205,17 +205,18 @@ class KBRDModel(BaseModel):
         return sum_logits, preds
 
     def decode_greedy(self, encoder_states, user_embedding):
+
         bsz = encoder_states[0].shape[0]
         xs = self._starts(bsz)
         incr_state = None
         logits = []
         for i in range(self.longest_label):
-            scores, incr_state = self.decoder(xs, encoder_states, incr_state)
+            scores, incr_state = self.decoder(xs, encoder_states, incr_state)  # incr_state is always None
             scores = scores[:, -1:, :]
             token_logits = F.linear(scores, self.token_embedding.weight)
             user_logits = self.user_proj_2(torch.relu(self.user_proj_1(user_embedding))).unsqueeze(1)
             sum_logits = token_logits + user_logits
-            _, preds = sum_logits.max(dim=-1)
+            probs, preds = sum_logits.max(dim=-1)
             logits.append(scores)
             xs = torch.cat([xs, preds], dim=1)
             # check if everyone has generated an end token
@@ -223,6 +224,62 @@ class KBRDModel(BaseModel):
             if all_finished:
                 break
         logits = torch.cat(logits, 1)
+        return logits, xs
+
+    def decode_beam_search(self, encoder_states, user_embedding, beam=4):
+        bsz = encoder_states[0].shape[0]
+        xs = self._starts(bsz).reshape(1, bsz, -1)  # (1, batch_size, _)
+        sequences = [[[list(), list(), 1.0]]] * bsz
+        for i in range(self.longest_label):
+            # at beginning there is 1 candidate, when i!=0 there are 4 candidates
+            if i != 0:
+                xs = []
+                for d in range(len(sequences[0])):
+                    for j in range(bsz):
+                        text = sequences[j][d][0]
+                        xs.append(text)
+                xs = torch.stack(xs).reshape(beam, bsz, -1)  # (beam, batch_size, _)
+
+            with torch.no_grad():
+                logits_list = []
+                scores_list = []
+                for x in xs:
+                    scores, _ = self.decoder(x, encoder_states)
+                    scores = scores[:, -1:, :]
+                    scores_list.append(scores)
+                    token_logits = F.linear(scores, self.token_embedding.weight)
+                    user_logits = self.user_proj_2(torch.relu(self.user_proj_1(user_embedding))).unsqueeze(1)
+                    sum_logits = token_logits + user_logits
+                    logits_list.append(sum_logits)
+
+            logits = torch.stack(logits_list)
+            logits = torch.nn.functional.softmax(logits)  # turn into probabilities,in case of negative numbers
+            scores = torch.stack(scores_list)
+            probs, preds = logits.topk(beam, dim=-1)
+            # (candeidate, bs, 1 , beam) during first loop, candidate=1, otherwise candidate=beam
+
+            for j in range(bsz):
+                all_candidates = []
+                for n in range(len(sequences[j])):
+                    for k in range(beam):
+                        prob = sequences[j][n][2]
+                        score = sequences[j][n][1]
+                        if score == []:
+                            score_tmp = scores[n][j][0].unsqueeze(0)
+                        else:
+                            score_tmp = torch.cat((score, scores[n][j][0].unsqueeze(0)), dim=0)
+                        seq_tmp = torch.cat((xs[n][j].reshape(-1), preds[n][j][0][k].reshape(-1)))
+                        candidate = [seq_tmp, score_tmp, prob * probs[n][j][0][k]]
+                        all_candidates.append(candidate)
+                ordered = sorted(all_candidates, key=lambda tup: tup[2], reverse=True)
+                sequences[j] = ordered[:beam]
+
+            # check if everyone has generated an end token
+            all_finished = ((xs == self.end_token_idx).sum(dim=1) > 0).sum().item() == bsz
+            if all_finished:
+                break
+        logits = torch.stack([seq[0][1] for seq in sequences])
+        xs = torch.stack([seq[0][0] for seq in sequences])
         return logits, xs
 
     def converse(self, batch, mode):
@@ -240,3 +297,9 @@ class KBRDModel(BaseModel):
         else:
             _, preds = self.decode_greedy(encoder_state, user_embedding)
             return preds
+
+    def forward(self, batch, mode, stage):
+        if stage == "conv":
+            return self.converse(batch, mode)
+        if stage == "rec":
+            return self.recommend(batch, mode)

--- a/crslab/model/crs/kgsf/kgsf.py
+++ b/crslab/model/crs/kgsf/kgsf.py
@@ -19,7 +19,6 @@ References:
 """
 
 import os
-
 import numpy as np
 import torch
 import torch.nn.functional as F
@@ -93,10 +92,12 @@ class KGSFModel(BaseModel):
         self.n_relation = entity_kg['n_relation']
         entity_edges = entity_kg['edge']
         self.entity_edge_idx, self.entity_edge_type = edge_to_pyg_format(entity_edges, 'RGCN')
-        self.entity_edge_idx = self.entity_edge_idx.to(device)
-        self.entity_edge_type = self.entity_edge_type.to(device)
+        self.entity_edge_idx = self.entity_edge_idx.cuda(torch.cuda.current_device())
+        self.entity_edge_type = self.entity_edge_type.cuda(torch.cuda.current_device())
         word_edges = side_data['word_kg']['edge']
-        self.word_edges = edge_to_pyg_format(word_edges, 'GCN').to(device)
+
+        self.word_edges = edge_to_pyg_format(word_edges, 'GCN').cuda(torch.cuda.current_device())
+
         self.num_bases = opt['num_bases']
         self.kg_emb_dim = opt['kg_emb_dim']
         # transformer
@@ -194,7 +195,7 @@ class KGSFModel(BaseModel):
         self.copy_norm = nn.Linear(self.ffn_size * 3, self.token_emb_dim)
         self.copy_output = nn.Linear(self.token_emb_dim, self.vocab_size)
         self.copy_mask = torch.as_tensor(np.load(os.path.join(self.dpath, "copy_mask.npy")).astype(bool),
-                                         device=self.device)
+                                         ).cuda(torch.cuda.current_device())
 
         self.conv_decoder = TransformerDecoderKG(
             self.n_heads, self.n_layers, self.token_emb_dim, self.ffn_size, self.vocab_size,
@@ -328,6 +329,70 @@ class KGSFModel(BaseModel):
         logits = torch.cat(logits, dim=1)
         return logits, inputs
 
+    def _decode_beam_search_with_kg(self, token_encoding, entity_reps, entity_emb_attn, entity_mask,
+                               word_reps, word_emb_attn, word_mask, beam=4):
+        batch_size = token_encoding[0].shape[0]
+        inputs = self._starts(batch_size).long().reshape(1, batch_size, -1)
+        incr_state = None
+        logits = []
+
+        sequences = [[[list(), list(), 1.0]]] * batch_size
+        for i in range(self.response_truncate):
+            # at beginning there is 1 candidate, when i!=0 there are 4 candidates
+            if i != 0:
+                inputs = []
+                for d in range(len(sequences[0])):
+                    for j in range(batch_size):
+                        text = sequences[j][d][0]
+                        inputs.append(text)
+                inputs = torch.stack(inputs).reshape(beam, batch_size, -1)  # (beam, batch_size, _)
+
+            with torch.no_grad():
+                logits_list = []
+                for x in inputs:
+                    dialog_latent, incr_state = self.conv_decoder(x, token_encoding, word_reps, word_mask,
+                                                                  entity_reps, entity_mask, incr_state)
+                    dialog_latent = dialog_latent[:, -1:, :]  # (bs, 1, dim)
+                    db_latent = entity_emb_attn.unsqueeze(1)
+                    concept_latent = word_emb_attn.unsqueeze(1)
+                    copy_latent = self.copy_norm(torch.cat((db_latent, concept_latent, dialog_latent), dim=-1))
+
+                    copy_logits = self.copy_output(copy_latent) * self.copy_mask.unsqueeze(0).unsqueeze(0)
+                    gen_logits = F.linear(dialog_latent, self.token_embedding.weight)
+                    sum_logits = copy_logits + gen_logits
+
+                    logits_list.append(sum_logits)
+
+            logits = torch.stack(logits_list)
+            # turn into probabilities,in case of negative numbers
+            probs, preds = torch.nn.functional.softmax(logits).topk(beam, dim=-1)
+
+            # (candeidate, bs, 1 , beam) during first loop, candidate=1, otherwise candidate=beam
+
+            for j in range(batch_size):
+                all_candidates = []
+                for n in range(len(sequences[j])):
+                    for k in range(beam):
+                        prob = sequences[j][n][2]
+                        logit = sequences[j][n][1]
+                        if logit == []:
+                            logit_tmp = logits[n][j][0].unsqueeze(0)
+                        else:
+                            logit_tmp = torch.cat((logit, logits[n][j][0].unsqueeze(0)), dim=0)
+                        seq_tmp = torch.cat((inputs[n][j].reshape(-1), preds[n][j][0][k].reshape(-1)))
+                        candidate = [seq_tmp, logit_tmp, prob * probs[n][j][0][k]]
+                        all_candidates.append(candidate)
+                ordered = sorted(all_candidates, key=lambda tup: tup[2], reverse=True)
+                sequences[j] = ordered[:beam]
+
+            # check if everyone has generated an end token
+            all_finished = ((inputs == self.end_token_idx).sum(dim=1) > 0).sum().item() == batch_size
+            if all_finished:
+                break
+        logits = torch.stack([seq[0][1] for seq in sequences])
+        inputs = torch.stack([seq[0][0] for seq in sequences])
+        return logits, inputs
+
     def converse(self, batch, mode):
         context_tokens, context_entities, context_words, response = batch
 
@@ -364,3 +429,18 @@ class KGSFModel(BaseModel):
                                                         entity_padding_mask,
                                                         conv_word_reps, conv_word_emb, word_padding_mask)
             return preds
+
+    def forward(self, batch, stage, mode):
+        #  forward function operate on different gpus, the weight of graph network need to be copied to other gpu
+        self.entity_edge_idx = self.entity_edge_idx.cuda(torch.cuda.current_device())
+        self.entity_edge_type = self.entity_edge_type.cuda(torch.cuda.current_device())
+        self.word_edges = self.word_edges.cuda(torch.cuda.current_device())
+        self.copy_mask = torch.as_tensor(np.load(os.path.join(self.dpath, "copy_mask.npy")).astype(bool),
+                                         ).cuda(torch.cuda.current_device())
+        if stage == "pretrain":
+            loss = self.pretrain_infomax(batch)
+        elif stage == "rec":
+            loss = self.recommend(batch, mode)
+        elif stage == "conv":
+            loss = self.converse(batch, mode)
+        return loss

--- a/crslab/model/crs/redial/redial_conv.py
+++ b/crslab/model/crs/redial/redial_conv.py
@@ -108,7 +108,7 @@ class ReDialConvModel(BaseModel):
         )
         self.loss = nn.CrossEntropyLoss(ignore_index=self.pad_token_idx)
 
-    def converse(self, batch, mode):
+    def forward(self, batch, mode):
         """
         Args:
             batch: ::

--- a/crslab/model/crs/redial/redial_rec.py
+++ b/crslab/model/crs/redial/redial_rec.py
@@ -76,7 +76,7 @@ class ReDialRecModel(BaseModel):
         self.decoder = nn.Linear(self.user_repr_dim, self.n_entity)
         self.loss = nn.CrossEntropyLoss()
 
-    def recommend(self, batch, mode):
+    def forward(self, batch, mode):
         """
 
         Args:

--- a/crslab/model/crs/tgredial/tg_conv.py
+++ b/crslab/model/crs/tgredial/tg_conv.py
@@ -64,7 +64,7 @@ class TGConvModel(BaseModel):
         self.model = GPT2LMHeadModel.from_pretrained(self.dpath)
         self.loss = CrossEntropyLoss(ignore_index=self.pad_id)
 
-    def converse(self, batch, mode):
+    def forward(self, batch, mode):
         if mode == 'test' or mode == 'infer':
             enhanced_context = batch[1]
             return self.generate(enhanced_context)
@@ -108,6 +108,47 @@ class TGConvModel(BaseModel):
         generated_response = torch.stack(generated_response).T
 
         return generated_response
+
+    def generate_bs(self, context, beam=4):
+        context = context[..., -self.response_truncate + 1:]
+        context_former = context
+        batch_size = context.shape[0]
+        sequences = [[[list(), 1.0]]] * batch_size
+        for i in range(self.response_truncate - 1):
+            if sequences != [[[list(), 1.0]]] * batch_size:
+                context = []
+                for i in range(batch_size):
+                    for cand in sequences[i]:
+                        text = torch.cat((context_former[i], torch.tensor(cand[0]).to(self.device)))  # 由于取消了state，与之前的context拼接
+                        context.append(text)
+                context = torch.stack(context)
+            with torch.no_grad():
+                outputs = self.model(context)
+            last_hidden_state, state = outputs.logits, outputs.past_key_values
+            next_token_logits = last_hidden_state[:, -1, :]
+            next_token_probs = torch.nn.functional.softmax(next_token_logits)
+            topk = torch.topk(next_token_probs, beam, dim=-1)
+            probs = topk.values.reshape([batch_size, -1, beam])  # (bs, candidate, beam)
+            preds = topk.indices.reshape([batch_size, -1, beam])  # (bs, candidate, beam)
+
+            for j in range(batch_size):
+                all_candidates = []
+                for n in range(len(sequences[j])):
+                    for k in range(beam):
+                        seq = sequences[j][n][0]
+                        prob = sequences[j][n][1]
+                        seq_tmp = seq.copy()
+                        seq_tmp.append(preds[j][n][k])
+                        candidate = [seq_tmp, prob * probs[j][n][k]]
+                        all_candidates.append(candidate)
+                ordered = sorted(all_candidates, key=lambda tup: tup[1], reverse=True)
+                sequences[j] = ordered[:beam]
+
+        res = []
+        for i in range(batch_size):
+            res.append(torch.stack(sequences[i][0][0]))
+        res = torch.stack(res)
+        return res
 
     def calculate_loss(self, logit, labels):
         """

--- a/crslab/model/crs/tgredial/tg_policy.py
+++ b/crslab/model/crs/tgredial/tg_policy.py
@@ -61,7 +61,7 @@ class TGPolicyModel(BaseModel):
 
         self.loss = nn.CrossEntropyLoss()
 
-    def guide(self, batch, mode):
+    def forward(self, batch, mode):
         # conv_id, message_id, context, context_mask, topic_path_kw, tp_mask, user_profile, profile_mask, y = batch
         context, context_mask, topic_path_kw, tp_mask, user_profile, profile_mask, y = batch
 

--- a/crslab/model/crs/tgredial/tg_rec.py
+++ b/crslab/model/crs/tgredial/tg_rec.py
@@ -91,7 +91,7 @@ class TGRecModel(BaseModel):
 
         logger.debug('[Finish build rec layer]')
 
-    def recommend(self, batch, mode):
+    def forward(self, batch, mode):
         context, mask, input_ids, target_pos, input_mask, sample_negs, y = batch
 
         bert_embed = self.bert(context, attention_mask=mask).pooler_output

--- a/crslab/model/policy/conv_bert/conv_bert.py
+++ b/crslab/model/policy/conv_bert/conv_bert.py
@@ -63,7 +63,7 @@ class ConvBERTModel(BaseModel):
 
         self.loss = nn.CrossEntropyLoss()
 
-    def guide(self, batch, mode):
+    def forward(self, batch, mode):
         # conv_id, message_id, context, context_mask, topic_path_kw, tp_mask, user_profile, profile_mask, y = batch
         context, context_mask, topic_path_kw, tp_mask, user_profile, profile_mask, y = batch
 

--- a/crslab/model/policy/mgcg/mgcg.py
+++ b/crslab/model/policy/mgcg/mgcg.py
@@ -87,7 +87,7 @@ class MGCGModel(BaseModel):
     def get_length(self, input):
         return [torch.sum((ids != 0).long()).item() for ids in input]
 
-    def guide(self, batch, mode):
+    def forward(self, batch, mode):
         # conv_id, message_id, context, context_mask, topic_path_kw, tp_mask, user_profile, profile_mask, y = batch
         context, context_mask, topic_path_kw, tp_mask, user_profile, profile_mask, y = batch
 

--- a/crslab/model/policy/pmi/pmi.py
+++ b/crslab/model/policy/pmi/pmi.py
@@ -48,7 +48,7 @@ class PMIModel(BaseModel):
         self.t2gram_to_num = defaultdict(int)
         self.last_topic_to_target_topic = defaultdict(int)
 
-    def guide(self, batch, mode):
+    def forward(self, batch, mode):
         # conv_id, message_id, context, context_mask, topic_path_kw, tp_mask, user_profile, profile_mask, y = batch
         context, context_mask, topic_path_kw, tp_mask, user_profile, profile_mask, target = batch
 

--- a/crslab/model/policy/profile_bert/profile_bert.py
+++ b/crslab/model/policy/profile_bert/profile_bert.py
@@ -67,7 +67,7 @@ class ProfileBERTModel(BaseModel):
 
         self.loss = nn.CrossEntropyLoss()
 
-    def guide(self, batch, mode):
+    def forward(self, batch, mode):
         # conv_id, message_id, context, context_mask, topic_path_kw, tp_mask, user_profile, profile_mask, y = batch
         context, context_mask, topic_path_kw, tp_mask, user_profile, profile_mask, y = batch
 

--- a/crslab/model/policy/topic_bert/topic_bert.py
+++ b/crslab/model/policy/topic_bert/topic_bert.py
@@ -65,7 +65,7 @@ class TopicBERTModel(BaseModel):
 
         self.loss = nn.CrossEntropyLoss()
 
-    def guide(self, batch, mode):
+    def forward(self, batch, mode):
         # conv_id, message_id, context, context_mask, topic_path_kw, tp_mask, user_profile, profile_mask, y = batch
         context, context_mask, topic_path_kw, tp_mask, user_profile, profile_mask, y = batch
 

--- a/crslab/model/recommendation/bert/bert.py
+++ b/crslab/model/recommendation/bert/bert.py
@@ -67,7 +67,7 @@ class BERTModel(BaseModel):
 
         logger.debug('[Finish build rec layer]')
 
-    def recommend(self, batch, mode='train'):
+    def forward(self, batch, mode='train'):
         context, mask, input_ids, target_pos, input_mask, sample_negs, y = batch
 
         bert_embed = self.bert(context, attention_mask=mask).pooler_output

--- a/crslab/model/recommendation/gru4rec/gru4rec.py
+++ b/crslab/model/recommendation/gru4rec/gru4rec.py
@@ -119,7 +119,7 @@ class GRU4RECModel(BaseModel):
 
         return loss
 
-    def recommend(self, batch, mode):
+    def forward(self, batch, mode):
         """
         Args:
             input_ids: padding in left, [pad, pad, id1, id2, ..., idn]

--- a/crslab/model/recommendation/gru4rec/gru4rec.py
+++ b/crslab/model/recommendation/gru4rec/gru4rec.py
@@ -68,7 +68,6 @@ class GRU4RECModel(BaseModel):
                           self.num_layers,
                           dropout=self.dropout_hidden,
                           batch_first=True)
-        self.rec_loss = self.cross_entropy
 
         logger.debug('[Finish build rec layer]')
 
@@ -147,7 +146,7 @@ class GRU4RECModel(BaseModel):
         rec_scores = rec_scores.squeeze(1)
 
         max_out_len = max([len_ for len_ in output_len])
-        rec_loss = self.rec_loss(logit, target_pos[:, :max_out_len],
+        rec_loss = self.cross_entropy(logit, target_pos[:, :max_out_len],
                                  sample_negs[:, :max_out_len], input_mask)
 
         return rec_loss, rec_scores

--- a/crslab/model/recommendation/popularity/popularity.py
+++ b/crslab/model/recommendation/popularity/popularity.py
@@ -45,7 +45,7 @@ class PopularityModel(BaseModel):
         self.item_frequency = defaultdict(int)
         logger.debug('[Finish build rec layer]')
 
-    def recommend(self, batch, mode):
+    def forward(self, batch, mode):
         context, mask, input_ids, target_pos, input_mask, sample_negs, y = batch
         if mode == 'train':
             for ids in input_ids:

--- a/crslab/model/recommendation/sasrec/modules.py
+++ b/crslab/model/recommendation/sasrec/modules.py
@@ -76,8 +76,8 @@ class SASRec(nn.Module):
         # positions we want to attend and -10000.0 for masked positions.
         # Since we are adding it to the raw scores before the softmax, this is
         # effectively the same as removing these entirely.
-        extended_attention_mask = extended_attention_mask.to(
-            dtype=next(self.parameters()).dtype)  # fp16 compatibility
+        #extended_attention_mask = extended_attention_mask.to(
+        #   dtype=next(self.parameters()).dtype)  # fp16 compatibility
         extended_attention_mask = (1.0 - extended_attention_mask) * -10000.0
         embedding = self.embeddings(input_ids)
 

--- a/crslab/model/recommendation/sasrec/sasrec.py
+++ b/crslab/model/recommendation/sasrec/sasrec.py
@@ -78,7 +78,7 @@ class SASRECModel(BaseModel):
 
         logger.debug('[Finish build rec layer]')
 
-    def recommend(self, batch, mode):
+    def forward(self, batch, mode):
         context, mask, input_ids, target_pos, input_mask, sample_negs, y = batch
         # print(input_ids.shape)
         sequence_output = self.SASREC(input_ids, input_mask)  # bs, max_len, hidden_size2

--- a/crslab/model/recommendation/textcnn/textcnn.py
+++ b/crslab/model/recommendation/textcnn/textcnn.py
@@ -73,7 +73,7 @@ class TextCNNModel(BaseModel):
 
         logger.debug('[Finish build rec layer]')
 
-    def recommend(self, batch, mode):
+    def forward(self, batch, mode):
         context, mask, input_ids, target_pos, input_mask, sample_negs, y = batch
 
         out = self.embedding(context)

--- a/crslab/system/base.py
+++ b/crslab/system/base.py
@@ -52,7 +52,12 @@ class BaseSystem(ABC):
 
         """
         self.opt = opt
-        self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+        if opt["gpu"] == [-1]:
+            self.device = torch.device('cpu')
+        elif len(opt["gpu"]) == 1:
+            self.device = torch.device('cuda', opt["gpu"][0])
+        else:
+            self.device = torch.device('cuda')
         # data
         if debug:
             self.train_dataloader = valid_dataloader
@@ -176,7 +181,7 @@ class BaseSystem(ABC):
         if self.update_freq > 1:
             self._number_grad_accum = (self._number_grad_accum + 1) % self.update_freq
             loss /= self.update_freq
-        loss.backward()
+        loss.backward(loss.clone().detach())
 
         self._update_params()
 

--- a/crslab/system/kbrd.py
+++ b/crslab/system/kbrd.py
@@ -16,6 +16,8 @@ from crslab.evaluator.metrics.base import AverageMetric
 from crslab.evaluator.metrics.gen import PPLMetric
 from crslab.system.base import BaseSystem
 from crslab.system.utils.functions import ind2txt
+from crslab.data.dataloader.utils import padded_tensor
+
 
 
 class KBRDSystem(BaseSystem):
@@ -73,12 +75,15 @@ class KBRDSystem(BaseSystem):
         assert stage in ('rec', 'conv')
         assert mode in ('train', 'valid', 'test')
 
+        batch["context_entities"] = padded_tensor(batch["context_entities"])
+
         for k, v in batch.items():
             if isinstance(v, torch.Tensor):
                 batch[k] = v.to(self.device)
 
         if stage == 'rec':
             rec_loss, rec_scores = self.model.forward(batch, mode, stage)
+            rec_loss = rec_loss.sum()
             if mode == 'train':
                 self.backward(rec_loss)
             else:

--- a/crslab/system/kbrd.py
+++ b/crslab/system/kbrd.py
@@ -8,6 +8,7 @@
 # @Author  :   Xiaolei Wang
 # @email   :   wxl1999@foxmail.com
 
+import os
 import torch
 from loguru import logger
 
@@ -77,7 +78,7 @@ class KBRDSystem(BaseSystem):
                 batch[k] = v.to(self.device)
 
         if stage == 'rec':
-            rec_loss, rec_scores = self.model.recommend(batch, mode)
+            rec_loss, rec_scores = self.model.forward(batch, mode, stage)
             if mode == 'train':
                 self.backward(rec_loss)
             else:
@@ -86,7 +87,7 @@ class KBRDSystem(BaseSystem):
             self.evaluator.optim_metrics.add("rec_loss", AverageMetric(rec_loss))
         else:
             if mode != 'test':
-                gen_loss, preds = self.model.converse(batch, mode)
+                gen_loss, preds = self.model.forward(batch, mode, stage)
                 if mode == 'train':
                     self.backward(gen_loss)
                 else:
@@ -95,7 +96,7 @@ class KBRDSystem(BaseSystem):
                 self.evaluator.optim_metrics.add('gen_loss', AverageMetric(gen_loss))
                 self.evaluator.gen_metrics.add("ppl", PPLMetric(gen_loss))
             else:
-                preds = self.model.converse(batch, mode)
+                preds = self.model.forward(batch, mode, stage)
                 self.conv_evaluate(preds, batch['response'])
 
     def train_recommender(self):

--- a/crslab/system/redial.py
+++ b/crslab/system/redial.py
@@ -79,7 +79,8 @@ class ReDialSystem(BaseSystem):
                 batch[k] = v.to(self.device)
 
         if stage == 'rec':
-            rec_loss, rec_scores = self.rec_model.recommend(batch, mode=mode)
+            rec_loss, rec_scores = self.rec_model.forward(batch, mode=mode)
+            rec_loss = rec_loss.sum()
             if mode == 'train':
                 self.backward(rec_loss)
             else:
@@ -87,7 +88,8 @@ class ReDialSystem(BaseSystem):
             rec_loss = rec_loss.item()
             self.evaluator.optim_metrics.add("rec_loss", AverageMetric(rec_loss))
         else:
-            gen_loss, preds = self.conv_model.converse(batch, mode=mode)
+            gen_loss, preds = self.conv_model.forward(batch, mode=mode)
+            gen_loss = gen_loss.sum()
             if mode == 'train':
                 self.backward(gen_loss)
             else:

--- a/crslab/system/tgredial.py
+++ b/crslab/system/tgredial.py
@@ -120,8 +120,8 @@ class TGReDialSystem(BaseSystem):
                 self.policy_model.eval()
 
             policy_loss, policy_predict = self.policy_model.forward(batch, mode)
-            policy_loss = policy_loss.sum()  # 多gpu训练会返回多个loss，需要合并为一个loss，单gpu训练时调用这个函数也不会报错
             if mode == "train" and policy_loss is not None:
+                policy_loss = policy_loss.sum()  # 多gpu训练会返回多个loss，需要合并为一个loss，单gpu训练时调用这个函数也不会报错
                 self.backward(policy_loss)
             else:
                 self.policy_evaluate(policy_predict, batch[-1])

--- a/crslab/system/tgredial.py
+++ b/crslab/system/tgredial.py
@@ -119,7 +119,8 @@ class TGReDialSystem(BaseSystem):
             else:
                 self.policy_model.eval()
 
-            policy_loss, policy_predict = self.policy_model.guide(batch, mode)
+            policy_loss, policy_predict = self.policy_model.forward(batch, mode)
+            policy_loss = policy_loss.sum()  # 多gpu训练会返回多个loss，需要合并为一个loss，单gpu训练时调用这个函数也不会报错
             if mode == "train" and policy_loss is not None:
                 self.backward(policy_loss)
             else:
@@ -133,8 +134,8 @@ class TGReDialSystem(BaseSystem):
                 self.rec_model.train()
             else:
                 self.rec_model.eval()
-
-            rec_loss, rec_predict = self.rec_model.recommend(batch, mode)
+            rec_loss, rec_predict = self.rec_model.forward(batch, mode)
+            rec_loss = rec_loss.sum()  # 多gpu训练会返回多个loss，需要合并为一个loss，单gpu训练时调用这个函数也不会报错
             if mode == "train":
                 self.backward(rec_loss)
             else:
@@ -145,7 +146,8 @@ class TGReDialSystem(BaseSystem):
         elif stage == "conv":
             if mode != "test":
                 # train + valid: need to compute ppl
-                gen_loss, pred = self.conv_model.converse(batch, mode)
+                gen_loss, pred = self.conv_model.forward(batch, mode)
+                gen_loss = gen_loss.sum()  # 多gpu训练会返回多个loss，需要合并为一个loss，单gpu训练时调用这个函数也不会报错
                 if mode == 'train':
                     self.backward(gen_loss)
                 else:
@@ -156,14 +158,17 @@ class TGReDialSystem(BaseSystem):
                 self.evaluator.gen_metrics.add("ppl", PPLMetric(gen_loss))
             else:
                 # generate response in conv_model.step
-                pred = self.conv_model.converse(batch, mode)
+                pred = self.conv_model.forward(batch, mode)
                 self.conv_evaluate(pred, batch[-1])
         else:
             raise
 
     def train_recommender(self):
         if hasattr(self.rec_model, 'bert'):
-            bert_param = list(self.rec_model.bert.named_parameters())
+            if os.environ["CUDA_VISIBLE_DEVICES"] == '-1':
+                bert_param = list(self.rec_model.bert.named_parameters())
+            else:
+                bert_param = list(self.rec_model.module.bert.named_parameters())
             bert_param_name = ['bert.' + n for n, p in bert_param]
         else:
             bert_param = []
@@ -201,6 +206,10 @@ class TGReDialSystem(BaseSystem):
                                                                   shuffle=False):
                 self.step(batch, stage='rec', mode='test')
             self.evaluator.report()
+        self.rec_model.cpu()  # 清理model占用的cuda显存
+        torch.cuda.empty_cache()  # 清理显存
+
+
 
     def train_conversation(self):
         self.init_optim(self.conv_optim_opt, self.conv_model.parameters())
@@ -230,6 +239,9 @@ class TGReDialSystem(BaseSystem):
                     batch_size=self.conv_batch_size, shuffle=False):
                 self.step(batch, stage='conv', mode='test')
             self.evaluator.report()
+
+        self.conv_model.cpu()
+        torch.cuda.empty_cache()  # 清理显存
 
     def train_policy(self):
         policy_params = list(self.policy_model.named_parameters())
@@ -276,6 +288,9 @@ class TGReDialSystem(BaseSystem):
                 self.step(batch, stage='policy', mode='test')
             self.evaluator.report()
 
+        self.policy_model.cpu()  # 清理model占用的cuda显存
+        torch.cuda.empty_cache()
+
     def fit(self):
         if hasattr(self, 'rec_model'):
             self.train_recommender()
@@ -291,7 +306,7 @@ class TGReDialSystem(BaseSystem):
             # rec
             if hasattr(self, 'rec_model'):
                 rec_input = self.process_input(input_text, 'rec')
-                scores = self.rec_model.recommend(rec_input, 'infer')
+                scores = self.rec_model.forward(rec_input, 'infer')
 
                 scores = scores.cpu()[0]
                 scores = scores[self.item_ids]
@@ -309,7 +324,7 @@ class TGReDialSystem(BaseSystem):
             # conv
             if hasattr(self, 'conv_model'):
                 conv_input = self.process_input(input_text, 'conv')
-                preds = self.conv_model.converse(conv_input, 'infer').tolist()[0]
+                preds = self.conv_model.forward(conv_input, 'infer').tolist()[0]
                 p_str = ind2txt(preds, self.ind2tok, self.end_token_idx)
 
                 token_ids, entity_ids, movie_ids, word_ids = self.convert_to_id(p_str, 'conv')


### PR DESCRIPTION
一：实现了多个模型的多gpu训练，采用torch.nn.DataParallel()对模型进行包装。
其中：
kgsf模型不支持cpu训练，由于初始化过程中设置将一部分模型放在gpu上；
kbrd模型不支持多gpu训练，由于传送给模型的batch中包含长度不一的list，torch.nn.DataParallel()没法将其分发给多gpu。
pmi运行失败，模型中返回loss设置为了None？
gru4rec不支持多gpu失败，与item_embedding有关，目前原因没找到。

二：实现了多个对话模型的beam search方法。
在gpt2这样的模型中，每次可以并行得出 beam_size * batch_size个结果，但是在kgsf模型中，用TransformerDecoderKG做生成时，第一次传入的数据是batch_size个,之后也只能用batch_size的大小输入，速度较慢。