### PR TITLE
FEA: add inspired system and tensorboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ data
 log
 save
 !crslab/data
+runs
 
 ### VisualStudioCode template
 .vscode/*

--- a/config/crs/inspired/durecdial.yaml
+++ b/config/crs/inspired/durecdial.yaml
@@ -1,0 +1,47 @@
+# dataset
+dataset: DuRecDial
+tokenize:
+  rec: bert
+  conv: gpt2
+# dataloader
+context_truncate: 256
+response_truncate: 30
+item_truncate: 100
+scale: 1
+# model
+# rec
+rec_model: InspiredRec
+# conv
+conv_model: InspiredConv
+# embedding: word2vec
+embedding_dim: 300
+use_dropout: False
+dropout: 0.3
+decoder_hidden_size: 256
+decoder_num_layers: 1
+# optim
+rec:
+  epoch: 1
+  batch_size: 8
+  optimizer:
+    name: AdamW
+    lr: !!float 1e-3
+    weight_decay: !!float 0.0000
+  early_stop: true
+  stop_mode: max
+  impatience: 3
+  lr_bert: !!float 1e-5
+conv:
+  epoch: 1
+  batch_size: 8
+  optimizer:
+    name: AdamW
+    lr: !!float 3e-5
+    eps: !!float 1e-06
+    weight_decay: !!float 0.01
+  lr_scheduler:
+    name: TransformersLinearLR
+    warmup_steps: 100
+  early_stop: true
+  impatience: 3
+  stop_mode: min

--- a/config/crs/inspired/gorecdial.yaml
+++ b/config/crs/inspired/gorecdial.yaml
@@ -1,0 +1,47 @@
+# dataset
+dataset: GoRecDial
+tokenize:
+  rec: bert
+  conv: gpt2
+# dataloader
+context_truncate: 256
+response_truncate: 30
+item_truncate: 100
+scale: 1
+# model
+# rec
+rec_model: InspiredRec
+# conv
+conv_model: InspiredConv
+# embedding: word2vec
+embedding_dim: 300
+use_dropout: False
+dropout: 0.3
+decoder_hidden_size: 256
+decoder_num_layers: 1
+# optim
+rec:
+  epoch: 1
+  batch_size: 8
+  optimizer:
+    name: AdamW
+    lr: !!float 1e-3
+    weight_decay: !!float 0.0000
+  early_stop: true
+  stop_mode: max
+  impatience: 3
+  lr_bert: !!float 1e-5
+conv:
+  epoch: 1
+  batch_size: 8
+  optimizer:
+    name: AdamW
+    lr: !!float 3e-5
+    eps: !!float 1e-06
+    weight_decay: !!float 0.01
+  lr_scheduler:
+    name: TransformersLinearLR
+    warmup_steps: 100
+  early_stop: true
+  impatience: 3
+  stop_mode: min

--- a/config/crs/inspired/inspired.yaml
+++ b/config/crs/inspired/inspired.yaml
@@ -1,0 +1,42 @@
+# dataset
+dataset: Inspired
+tokenize:
+  rec: bert
+  conv: gpt2
+# dataloader
+context_truncate: 256
+response_truncate: 30
+item_truncate: 100
+scale: 1
+# model
+# rec
+rec_model: InspiredRec
+# conv
+conv_model: InspiredConv
+# optim
+rec:
+  epoch: 1
+  batch_size: 8
+  optimizer:
+    name: AdamW
+    lr: !!float 1e-3
+    weight_decay: !!float 0.0000
+  early_stop: true
+  stop_mode: max
+  impatience: 3
+  lr_bert: !!float 1e-5
+conv:
+  epoch: 50
+  batch_size: 1
+  optimizer:
+    name: AdamW
+    lr: !!float 3e-5
+    eps: !!float 1e-06
+    weight_decay: !!float 0.01
+  lr_scheduler:
+    name: TransformersLinearLR
+    warmup_steps: 100
+  early_stop: true
+  impatience: 3
+  stop_mode: min
+  label_smoothing: -1

--- a/config/crs/inspired/opendialkg.yaml
+++ b/config/crs/inspired/opendialkg.yaml
@@ -1,0 +1,47 @@
+# dataset
+dataset: OpenDialKG
+tokenize:
+  rec: bert
+  conv: gpt2
+# dataloader
+context_truncate: 256
+response_truncate: 30
+item_truncate: 100
+scale: 1
+# model
+# rec
+rec_model: InspiredRec
+# conv
+conv_model: InspiredConv
+# embedding: word2vec
+embedding_dim: 300
+use_dropout: False
+dropout: 0.3
+decoder_hidden_size: 256
+decoder_num_layers: 1
+# optim
+rec:
+  epoch: 1
+  batch_size: 8
+  optimizer:
+    name: AdamW
+    lr: !!float 1e-3
+    weight_decay: !!float 0.0000
+  early_stop: true
+  stop_mode: max
+  impatience: 3
+  lr_bert: !!float 1e-5
+conv:
+  epoch: 1
+  batch_size: 8
+  optimizer:
+    name: AdamW
+    lr: !!float 3e-5
+    eps: !!float 1e-06
+    weight_decay: !!float 0.01
+  lr_scheduler:
+    name: TransformersLinearLR
+    warmup_steps: 100
+  early_stop: true
+  impatience: 3
+  stop_mode: min

--- a/config/crs/inspired/redial.yaml
+++ b/config/crs/inspired/redial.yaml
@@ -1,0 +1,47 @@
+# dataset
+dataset: Redial
+tokenize:
+  rec: bert
+  conv: gpt2
+# dataloader
+context_truncate: 256
+response_truncate: 30
+item_truncate: 100
+scale: 1
+# model
+# rec
+rec_model: InspiredRec
+# conv
+conv_model: InspiredConv
+# embedding: word2vec
+embedding_dim: 300
+use_dropout: False
+dropout: 0.3
+decoder_hidden_size: 256
+decoder_num_layers: 1
+# optim
+rec:
+  epoch: 1
+  batch_size: 8
+  optimizer:
+    name: AdamW
+    lr: !!float 1e-3
+    weight_decay: !!float 0.0000
+  early_stop: true
+  stop_mode: max
+  impatience: 3
+  lr_bert: !!float 1e-5
+conv:
+  epoch: 1
+  batch_size: 8
+  optimizer:
+    name: AdamW
+    lr: !!float 3e-5
+    eps: !!float 1e-06
+    weight_decay: !!float 0.01
+  lr_scheduler:
+    name: TransformersLinearLR
+    warmup_steps: 100
+  early_stop: true
+  impatience: 3
+  stop_mode: min

--- a/config/crs/inspired/tgredial.yaml
+++ b/config/crs/inspired/tgredial.yaml
@@ -1,0 +1,47 @@
+# dataset
+dataset: TGRedial
+tokenize:
+  rec: bert
+  conv: gpt2
+# dataloader
+context_truncate: 256
+response_truncate: 30
+item_truncate: 100
+scale: 1
+# model
+# rec
+rec_model: InspiredRec
+# conv
+conv_model: InspiredConv
+# embedding: word2vec
+embedding_dim: 300
+use_dropout: False
+dropout: 0.3
+decoder_hidden_size: 256
+decoder_num_layers: 1
+# optim
+rec:
+  epoch: 1
+  batch_size: 8
+  optimizer:
+    name: AdamW
+    lr: !!float 1e-3
+    weight_decay: !!float 0.0000
+  early_stop: true
+  stop_mode: max
+  impatience: 3
+  lr_bert: !!float 1e-5
+conv:
+  epoch: 1
+  batch_size: 8
+  optimizer:
+    name: AdamW
+    lr: !!float 3e-5
+    eps: !!float 1e-06
+    weight_decay: !!float 0.01
+  lr_scheduler:
+    name: TransformersLinearLR
+    warmup_steps: 100
+  early_stop: true
+  impatience: 3
+  stop_mode: min

--- a/crslab/data/__init__.py
+++ b/crslab/data/__init__.py
@@ -49,6 +49,7 @@ dataloader_register_table = {
     'ReDialRec': ReDialDataLoader,
     'ReDialConv': ReDialDataLoader,
     'ReDialRec_ReDialConv': ReDialDataLoader,
+    'InspiredRec_InspiredConv': InspiredDataLoader,
     'BERT': TGReDialDataLoader,
     'SASREC': TGReDialDataLoader,
     'TextCNN': TGReDialDataLoader,

--- a/crslab/data/dataloader/__init__.py
+++ b/crslab/data/dataloader/__init__.py
@@ -3,3 +3,4 @@ from .kbrd import KBRDDataLoader
 from .kgsf import KGSFDataLoader
 from .redial import ReDialDataLoader
 from .tgredial import TGReDialDataLoader
+from .inspired import InspiredDataLoader

--- a/crslab/data/dataloader/inspired.py
+++ b/crslab/data/dataloader/inspired.py
@@ -1,0 +1,163 @@
+# @Time   : 2020/3/11
+# @Author : Beichen Zhang
+# @Email  : zhangbeichen724@gmail.com
+
+import random
+from copy import deepcopy
+
+import torch
+from tqdm import tqdm
+
+from crslab.data.dataloader.base import BaseDataLoader
+from crslab.data.dataloader.utils import add_start_end_token_idx, padded_tensor, truncate, merge_utt
+
+
+class InspiredDataLoader(BaseDataLoader):
+    """Dataloader for model Inspired.
+
+    Notes:
+        You can set the following parameters in config:
+
+        - ``'context_truncate'``: the maximum length of context.
+        - ``'response_truncate'``: the maximum length of response.
+        - ``'entity_truncate'``: the maximum length of mentioned entities in context.
+        - ``'word_truncate'``: the maximum length of mentioned words in context.
+        - ``'item_truncate'``: the maximum length of mentioned items in context.
+
+        The following values must be specified in ``vocab``:
+
+        - ``'pad'``
+        - ``'start'``
+        - ``'end'``
+        - ``'unk'``
+        - ``'pad_entity'``
+        - ``'pad_word'``
+
+        the above values specify the id of needed special token.
+
+        - ``'ind2tok'``: map from index to token.
+        - ``'tok2ind'``: map from token to index.
+        - ``'vocab_size'``: size of vocab.
+        - ``'id2entity'``: map from index to entity.
+        - ``'n_entity'``: number of entities in the entity KG of dataset.
+        - ``'sent_split'`` (optional): token used to split sentence. Defaults to ``'end'``.
+        - ``'word_split'`` (optional): token used to split word. Defaults to ``'end'``.
+
+    """
+
+    def __init__(self, opt, dataset, vocab):
+        """
+
+        Args:
+            opt (Config or dict): config for dataloader or the whole system.
+            dataset: data for model.
+            vocab (dict): all kinds of useful size, idx and map between token and idx.
+
+        """
+        super().__init__(opt, dataset)
+
+        self.n_entity = vocab['n_entity']
+        self.pad_token_idx = vocab['pad']
+        self.start_token_idx = vocab['start']
+        self.end_token_idx = vocab['end']
+        self.unk_token_idx = vocab['unk']
+        self.conv_bos_id = vocab['start']
+        self.cls_id = vocab['start']
+        self.sep_id = vocab['end']
+        if 'sent_split' in vocab:
+            self.sent_split_idx = vocab['sent_split']
+        else:
+            self.sent_split_idx = vocab['end']
+
+        self.pad_entity_idx = vocab['pad_entity']
+        self.pad_word_idx = vocab['pad_word']
+
+        self.tok2ind = vocab['tok2ind']
+        self.ind2tok = vocab['ind2tok']
+        self.id2entity = vocab['id2entity']
+
+        self.context_truncate = opt.get('context_truncate', None)
+        self.response_truncate = opt.get('response_truncate', None)
+
+    def rec_process_fn(self, *args, **kwargs):
+        augment_dataset = []
+        for conv_dict in tqdm(self.dataset):
+            if conv_dict['role'] == 'Recommender':
+                for movie in conv_dict['items']:
+                    augment_conv_dict = deepcopy(conv_dict)
+                    augment_conv_dict['item'] = movie
+                    augment_dataset.append(augment_conv_dict)
+        return augment_dataset
+
+    def _process_rec_context(self, context_tokens):
+        compact_context = []
+        for i, utterance in enumerate(context_tokens):
+            if i != 0:
+                utterance.insert(0, self.sent_split_idx)
+            compact_context.append(utterance)
+        compat_context = truncate(merge_utt(compact_context),
+                                  self.context_truncate - 2,
+                                  truncate_tail=False)
+        compat_context = add_start_end_token_idx(compat_context,
+                                                 self.start_token_idx,
+                                                 self.end_token_idx)
+        return compat_context
+
+    def rec_batchify(self, batch):
+        batch_context = []
+        batch_movie_id = []
+
+        for conv_dict in batch:
+            context = self._process_rec_context(conv_dict['context_tokens'])
+            batch_context.append(context)
+
+            item_id = conv_dict['item']
+            batch_movie_id.append(item_id)
+
+        batch_context = padded_tensor(batch_context,
+                                      self.pad_token_idx,
+                                      max_len=self.context_truncate)
+        batch_mask = (batch_context != 0).long()
+
+        return (batch_context, batch_mask, torch.tensor(batch_movie_id))
+
+    def conv_batchify(self, batch):
+        """get batch and corresponding roles
+        """
+        batch_roles = []
+        batch_context_tokens = []
+        batch_response = []
+
+        for conv_dict in batch:
+            batch_roles.append(0 if conv_dict['role'] == 'Seeker' else 1)
+            context_tokens = [utter + [self.conv_bos_id] for utter in conv_dict['context_tokens']]
+            context_tokens[-1] = context_tokens[-1][:-1]
+            batch_context_tokens.append(
+                truncate(merge_utt(context_tokens), max_length=self.context_truncate, truncate_tail=False),
+            )
+            batch_response.append(
+                add_start_end_token_idx(
+                    truncate(conv_dict['response'], max_length=self.response_truncate - 2),
+                    start_token_idx=self.start_token_idx,
+                    end_token_idx=self.end_token_idx
+                )
+            )
+
+        batch_context_tokens = padded_tensor(items=batch_context_tokens,
+                                             pad_idx=self.pad_token_idx,
+                                             max_len=self.context_truncate,
+                                             pad_tail=False)
+        batch_response = padded_tensor(batch_response,
+                                       pad_idx=self.pad_token_idx,
+                                       max_len=self.response_truncate,
+                                       pad_tail=True)
+        batch_input_ids = torch.cat((batch_context_tokens, batch_response), dim=1)
+        batch_roles = torch.tensor(batch_roles)
+
+        return (batch_roles,
+                batch_input_ids,
+                batch_context_tokens,
+                batch_response)
+
+    def policy_batchify(self, batch):
+        pass

--- a/crslab/data/dataloader/inspired.py
+++ b/crslab/data/dataloader/inspired.py
@@ -1,4 +1,4 @@
-# @Time   : 2020/3/11
+# @Time   : 2021/3/11
 # @Author : Beichen Zhang
 # @Email  : zhangbeichen724@gmail.com
 
@@ -117,7 +117,7 @@ class InspiredDataLoader(BaseDataLoader):
         batch_context = padded_tensor(batch_context,
                                       self.pad_token_idx,
                                       max_len=self.context_truncate)
-        batch_mask = (batch_context != 0).long()
+        batch_mask = (batch_context != self.pad_token_idx).long()
 
         return (batch_context, batch_mask, torch.tensor(batch_movie_id))
 

--- a/crslab/data/dataloader/tgredial.py
+++ b/crslab/data/dataloader/tgredial.py
@@ -174,7 +174,7 @@ class TGReDialDataLoader(BaseDataLoader):
         batch_context = padded_tensor(batch_context,
                                       self.pad_token_idx,
                                       max_len=self.context_truncate)
-        batch_mask = (batch_context != 0).long()
+        batch_mask = (batch_context != self.pad_token_idx).long()
 
         return (batch_context, batch_mask,
                 padded_tensor(batch_input_ids,
@@ -207,7 +207,7 @@ class TGReDialDataLoader(BaseDataLoader):
         context = padded_tensor(context,
                                 self.pad_token_idx,
                                 max_len=self.context_truncate)
-        mask = (context != 0).long()
+        mask = (context != self.pad_token_idx).long()
 
         return (context, mask,
                 padded_tensor(input_ids,
@@ -395,7 +395,7 @@ class TGReDialDataLoader(BaseDataLoader):
                                       pad_idx=self.pad_token_idx,
                                       pad_tail=True,
                                       max_len=self.context_truncate)
-        batch_cotnext_mask = (batch_context != 0).long()
+        batch_cotnext_mask = (batch_context != self.pad_token_idx).long()
         batch_context_policy = padded_tensor(batch_context_policy,
                                              pad_idx=self.pad_token_idx,
                                              pad_tail=True)

--- a/crslab/evaluator/__init__.py
+++ b/crslab/evaluator/__init__.py
@@ -22,13 +22,13 @@ Evaluator_register_table = {
 }
 
 
-def get_evaluator(evaluator_name, dataset):
+def get_evaluator(evaluator_name, dataset, tensorboard=False):
     if evaluator_name in Evaluator_register_table:
         if evaluator_name in ('conv', 'standard'):
             language = dataset_language_map[dataset]
-            evaluator = Evaluator_register_table[evaluator_name](language)
+            evaluator = Evaluator_register_table[evaluator_name](language, tensorboard=tensorboard)
         else:
-            evaluator = Evaluator_register_table[evaluator_name]()
+            evaluator = Evaluator_register_table[evaluator_name](tensorboard=tensorboard)
         logger.info(f'[Build evaluator {evaluator_name}]')
         return evaluator
     else:

--- a/crslab/evaluator/base.py
+++ b/crslab/evaluator/base.py
@@ -23,7 +23,7 @@ class BaseEvaluator(ABC):
         pass
 
     @abstractmethod
-    def report(self):
+    def report(self, epoch, mode):
         pass
 
     @abstractmethod

--- a/crslab/model/__init__.py
+++ b/crslab/model/__init__.py
@@ -22,6 +22,8 @@ Model_register_table = {
     'TGPolicy': TGPolicyModel,
     'ReDialRec': ReDialRecModel,
     'ReDialConv': ReDialConvModel,
+    'InspiredRec': InspiredRecModel,
+    'InspiredConv': InspiredConvModel,
     'GPT2': GPT2Model,
     'Transformer': TransformerModel,
     'ConvBERT': ConvBERTModel,

--- a/crslab/model/crs/__init__.py
+++ b/crslab/model/crs/__init__.py
@@ -2,3 +2,4 @@ from .kbrd import *
 from .kgsf import *
 from .redial import *
 from .tgredial import *
+from .inspired import *

--- a/crslab/model/crs/inspired/__init__.py
+++ b/crslab/model/crs/inspired/__init__.py
@@ -1,0 +1,2 @@
+from .inspired_conv import InspiredConvModel
+from .inspired_rec import InspiredRecModel

--- a/crslab/model/crs/inspired/inspired_conv.py
+++ b/crslab/model/crs/inspired/inspired_conv.py
@@ -1,0 +1,145 @@
+# @Time   : 2021/3/10
+# @Author : Beichen Zhang
+# @Email  : zhangbeichen724@gmail.com
+
+import os
+
+import torch
+from transformers import GPT2LMHeadModel
+
+from crslab.config import PRETRAIN_PATH
+from crslab.data import dataset_language_map
+from crslab.model.base import BaseModel
+from crslab.model.pretrained_models import resources
+from .modules import SequenceCrossEntropyLoss
+
+class InspiredConvModel(BaseModel):
+    """
+
+    Attributes:
+        context_truncate: A integer indicating the length of dialogue context.
+        response_truncate: A integer indicating the length of dialogue response.
+        pad_id: A integer indicating the id of padding token.
+
+    """
+
+    def __init__(self, opt, device, vocab, side_data):
+        """
+
+        Args:
+            opt (dict): A dictionary record the hyper parameters.
+            device (torch.device): A variable indicating which device to place the data and model.
+            vocab (dict): A dictionary record the vocabulary information.
+            side_data (dict): A dictionary record the side data.
+
+        """
+        self.context_truncate = opt['context_truncate']
+        self.response_truncate = opt['response_truncate']
+        self.pad_id = vocab['pad']
+        self.label_smoothing = opt['conv']['label_smoothing'] if 'label_smoothing' in opt['conv'] else -1
+
+        language = dataset_language_map[opt['dataset']]
+        resource = resources['gpt2'][language]
+        dpath = os.path.join(PRETRAIN_PATH, "gpt2", language)
+        super(InspiredConvModel, self).__init__(opt, device, dpath, resource)
+
+    def build_model(self):
+        """build model for seeker and recommender separately"""
+        self.model_sk = GPT2LMHeadModel.from_pretrained(self.dpath)
+        self.model_rm = GPT2LMHeadModel.from_pretrained(self.dpath)
+        self.loss = SequenceCrossEntropyLoss(self.pad_id, self.label_smoothing)
+
+    def converse(self, batch, mode):
+        """
+        Args:
+            batch: ::
+
+                {
+                    'roles': (batch_size),
+                    'input_ids': (batch_size, max_seq_length),
+                    'context': (batch_size, context_truncate)
+                }
+
+        """
+        roles, input_ids, context, _ = batch
+        input_ids_iters = input_ids.unsqueeze(1)
+
+        past = None
+        lm_logits_all = []
+
+        if mode != 'test':
+            for turn, iter in enumerate(input_ids_iters):
+                if (roles[turn] == 0):
+                    # considering that gpt2 only supports up to 1024 tokens
+                    if past is not None and past[0].shape[3] + iter.shape[1] > 1024:
+                        past = None
+                    outputs = self.model_sk(iter, past_key_values=past)
+                    lm_logits, past = outputs.logits, outputs.past_key_values
+                    lm_logits_all.append(lm_logits)
+                else:
+                    if past is not None and past[0].shape[3] + iter.shape[1] > 1024:
+                        past = None
+                    outputs = self.model_rm(iter, past_key_values=past)
+                    lm_logits, past = outputs.logits, outputs.past_key_values
+                    lm_logits_all.append(lm_logits)
+
+            lm_logits_all = torch.cat(lm_logits_all, dim=0) # (b_s, seq_len, vocab_size)
+
+            # index from 1 to self.reponse_truncate is valid response
+            loss = self.calculate_loss(
+                lm_logits_all[:, -self.response_truncate:-1, :],
+                input_ids[:, -self.response_truncate + 1:])
+
+            pred = torch.max(lm_logits_all, dim=2)[1]  # (b_s, seq_len)
+            pred = pred[:, -self.response_truncate:]
+
+            return loss, pred
+        else:
+            return self.generate(roles, context)
+
+    def generate(self, roles, context):
+        """
+        Args:
+            roles: the role of each speak corresponding to the utterance in batch, shape=(b_s)
+            context: torch.tensor, shape=(b_s, context_turncate)
+
+        Returns:
+            generated_response: torch.tensor, shape=(b_s, reponse_turncate-1)
+        """
+        generated_response = []
+        former_hidden_state = None
+        context = context[..., -self.response_truncate + 1:]
+
+        for i in range(self.response_truncate - 1):
+            last_hidden_state_all = []
+            context_iters = context.unsqueeze(1)
+            for turn, iter in enumerate(context_iters):
+                if roles[turn] == 0:
+                    outputs = self.model_sk(iter, former_hidden_state)  # (1, s_l, v_s),
+                else:
+                    outputs = self.model_rm(iter, former_hidden_state)  # (1, s_l, v_s),
+                last_hidden_state, former_hidden_state = outputs.logits, outputs.past_key_values
+                last_hidden_state_all.append(last_hidden_state)
+
+            last_hidden_state_all = torch.cat(last_hidden_state_all, dim=0)
+            next_token_logits = last_hidden_state_all[:, -1, :]  # (b_s, v_s)
+            preds = next_token_logits.argmax(dim=-1).long()  # (b_s)
+
+            context = preds.unsqueeze(1)
+            generated_response.append(preds)
+
+        generated_response = torch.stack(generated_response).T
+
+        return generated_response
+
+    def calculate_loss(self, logit, labels):
+        """
+
+        Args:
+            preds: torch.FloatTensor, shape=(b_s, response_truncate, vocab_size)
+            labels: torch.LongTensor, shape=(b_s, response_truncate)
+
+        """
+
+        loss = self.loss(logit, labels)
+        return loss

--- a/crslab/model/crs/inspired/inspired_rec.py
+++ b/crslab/model/crs/inspired/inspired_rec.py
@@ -1,0 +1,79 @@
+# @Time   : 2020/12/16
+# @Author : Yuanhang Zhou
+# @Email  : sdzyh002@gmail.com
+
+# UPDATE
+# @Time   : 2021/1/7, 2021/1/4
+# @Author : Xiaolei Wang, Yuanhang Zhou
+# @email  : wxl1999@foxmail.com, sdzyh002@gmail.com
+
+r"""
+BERT
+====
+References:
+    Devlin, Jacob, et al. `"BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding."`_ in NAACL 2019.
+
+.. _`"BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding."`:
+   https://www.aclweb.org/anthology/N19-1423/
+
+"""
+
+import os
+
+from loguru import logger
+from torch import nn
+from transformers import BertModel
+
+from crslab.config import PRETRAIN_PATH
+from crslab.data import dataset_language_map
+from crslab.model.base import BaseModel
+from crslab.model.pretrained_models import resources
+
+
+class InspiredRecModel(BaseModel):
+    """
+
+    Attributes:
+        item_size: A integer indicating the number of items.
+
+    """
+
+    def __init__(self, opt, device, vocab, side_data):
+        """
+
+        Args:
+            opt (dict): A dictionary record the hyper parameters.
+            device (torch.device): A variable indicating which device to place the data and model.
+            vocab (dict): A dictionary record the vocabulary information.
+            side_data (dict): A dictionary record the side data.
+
+        """
+        self.item_size = vocab['n_entity']
+
+        language = dataset_language_map[opt['dataset']]
+        resource = resources['bert'][language]
+        dpath = os.path.join(PRETRAIN_PATH, "bert", language)
+        super(InspiredRecModel, self).__init__(opt, device, dpath, resource)
+
+    def build_model(self):
+        # build BERT layer, give the architecture, load pretrained parameters
+        self.bert = BertModel.from_pretrained(self.dpath)
+        # print(self.item_size)
+        self.bert_hidden_size = self.bert.config.hidden_size
+        self.mlp = nn.Linear(self.bert_hidden_size, self.item_size)
+
+        # this loss may conduct to some weakness
+        self.rec_loss = nn.CrossEntropyLoss()
+
+        logger.debug('[Finish build rec layer]')
+
+    def recommend(self, batch, mode='train'):
+        context, mask, y = batch
+
+        bert_embed = self.bert(context, attention_mask=mask).pooler_output
+
+        rec_scores = self.mlp(bert_embed)  # bs, item_size
+
+        rec_loss = self.rec_loss(rec_scores, y)
+
+        return rec_loss, rec_scores

--- a/crslab/model/crs/inspired/modules.py
+++ b/crslab/model/crs/inspired/modules.py
@@ -1,0 +1,56 @@
+# @Time   : 2021/3/10
+# @Author : Beichen Zhang
+# @Email  : zhangbeichen724@gmail.com
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+class SequenceCrossEntropyLoss(nn.Module):
+    """
+
+    Attributes:
+        ignore_index: indices corresponding tokens which should be ignored in calculating loss.
+        label_smoothing: determine smoothing value in cross entropy loss. should be less than 1.0.
+
+    """
+    def __init__(self, ignore_index=None, label_smoothing=-1):
+        super().__init__()
+        self.ignore_index = ignore_index
+        self.label_smoothing = label_smoothing
+
+    def forward(self, logits, labels):
+        """
+
+        Args:
+            logits: (batch_size, max_seq_len, vocal_size)
+            labels: (batch_size, max_seq_len)
+
+        """
+        if self.label_smoothing > 1.0:
+            raise ValueError('The param label_smoothing should be in the range of 0.0 to 1.0.')
+        if self.ignore_index == None:
+            mask = torch.ones_like(labels, dtype=torch.float)
+        else:
+            mask = (labels != self.ignore_index).float()
+        logits_flat = logits.reshape(-1, logits.size(-1))   # (b_s * s_l, num_classes)
+        log_probs_flat = F.log_softmax(logits_flat, dim=-1)
+        labels_flat = labels.reshape(-1, 1).long()  # (b_s * s_l, 1)
+
+        if self.label_smoothing > 0.0:
+            num_classes = logits.size(-1)
+            smoothing_value = self.label_smoothing / float(num_classes)
+            one_hot_labels = torch.zeros_like(log_probs_flat).scatter_(-1, labels_flat, 1.0 - self.label_smoothing) # fill all the correct indices with 1 - smoothing value.
+            smoothed_labels = one_hot_labels + smoothing_value
+            negative_log_likelihood_flat = -log_probs_flat * smoothed_labels
+            negative_log_likelihood_flat = negative_log_likelihood_flat.sum(-1, keepdim=True)
+        else:
+            negative_log_likelihood_flat = -torch.gather(log_probs_flat, dim=1, index=labels_flat) # (b_s * s_l, 1)
+
+        negative_log_likelihood = negative_log_likelihood_flat.view(-1, logits.shape[1])    # (b_s, s_l)
+        loss = negative_log_likelihood * mask
+
+        loss = loss.sum(1) / (mask.sum(1) + 1e-13)
+        loss = loss.mean()
+
+        return loss

--- a/crslab/quick_start/quick_start.py
+++ b/crslab/quick_start/quick_start.py
@@ -14,7 +14,7 @@ from crslab.system import get_system
 
 
 def run_crslab(config, save_data=False, restore_data=False, save_system=False, restore_system=False,
-               interact=False, debug=False):
+               interact=False, debug=False, tensorboard=False):
     """A fast running api, which includes the complete process of training and testing models on specified datasets.
 
     Args:
@@ -66,7 +66,7 @@ def run_crslab(config, save_data=False, restore_data=False, save_system=False, r
             test_dataloader[task] = get_dataloader(config, test_data, vocab[task])
     # system
     CRS = get_system(config, train_dataloader, valid_dataloader, test_dataloader, vocab, side_data, restore_system,
-                     interact, debug)
+                     interact, debug, tensorboard)
     if interact:
         CRS.interact()
     else:

--- a/crslab/system/__init__.py
+++ b/crslab/system/__init__.py
@@ -12,6 +12,7 @@ from loguru import logger
 from .kbrd import KBRDSystem
 from .kgsf import KGSFSystem
 from .redial import ReDialSystem
+from .inspired import InspiredSystem
 from .tgredial import TGReDialSystem
 
 system_register_table = {
@@ -20,6 +21,7 @@ system_register_table = {
     'KGSF': KGSFSystem,
     'TGRec_TGConv': TGReDialSystem,
     'TGRec_TGConv_TGPolicy': TGReDialSystem,
+    'InspiredRec_InspiredConv': InspiredSystem,
     'GPT2': TGReDialSystem,
     'Transformer': TGReDialSystem,
     'ConvBERT': TGReDialSystem,

--- a/crslab/system/__init__.py
+++ b/crslab/system/__init__.py
@@ -38,14 +38,14 @@ system_register_table = {
 
 
 def get_system(opt, train_dataloader, valid_dataloader, test_dataloader, vocab, side_data, restore_system=False,
-               interact=False, debug=False):
+               interact=False, debug=False, tensorboard=False):
     """
     return the system class
     """
     model_name = opt['model_name']
     if model_name in system_register_table:
         system = system_register_table[model_name](opt, train_dataloader, valid_dataloader, test_dataloader, vocab,
-                                                   side_data, restore_system, interact, debug)
+                                                   side_data, restore_system, interact, debug, tensorboard)
         logger.info(f'[Build system {model_name}]')
         return system
     else:

--- a/crslab/system/base.py
+++ b/crslab/system/base.py
@@ -36,7 +36,7 @@ class BaseSystem(ABC):
     """Base class for all system"""
 
     def __init__(self, opt, train_dataloader, valid_dataloader, test_dataloader, vocab, side_data, restore_system=False,
-                 interact=False, debug=False):
+                 interact=False, debug=False, tensorboard=False):
         """
 
         Args:
@@ -49,6 +49,7 @@ class BaseSystem(ABC):
             restore_system (bool, optional): Indicating if we store system after training. Defaults to False.
             interact (bool, optional): Indicating if we interact with system. Defaults to False.
             debug (bool, optional): Indicating if we train in debug mode. Defaults to False.
+            tensorboard (bool, optional) Indicating if we monitor the training performance in tensorboard. Defaults to False. 
 
         """
         self.opt = opt
@@ -83,7 +84,7 @@ class BaseSystem(ABC):
             self.restore_model()
 
         if not interact:
-            self.evaluator = get_evaluator(opt.get('evaluator', 'standard'), opt['dataset'])
+            self.evaluator = get_evaluator(opt.get('evaluator', 'standard'), opt['dataset'], tensorboard)
 
     def init_optim(self, opt, parameters):
         self.optim_opt = opt

--- a/crslab/system/inspired.py
+++ b/crslab/system/inspired.py
@@ -1,0 +1,211 @@
+# @Time   : 2021/3/1
+# @Author : Beichen Zhang
+# @Email  : zhangbeichen724@gmail.com
+
+import os
+import gc
+from math import floor
+
+import torch
+from loguru import logger
+
+from crslab.config import PRETRAIN_PATH
+from crslab.data import get_dataloader, dataset_language_map
+from crslab.evaluator.metrics.base import AverageMetric
+from crslab.evaluator.metrics.gen import PPLMetric
+from crslab.system.base import BaseSystem
+from crslab.system.utils.functions import ind2txt
+
+
+class InspiredSystem(BaseSystem):
+    """This is the system for Inspired model"""
+
+    def __init__(self, opt, train_dataloader, valid_dataloader, test_dataloader, vocab, side_data, restore_system=False,
+                 interact=False, debug=False):
+        """
+
+        Args:
+            opt (dict): Indicating the hyper parameters.
+            train_dataloader (BaseDataLoader): Indicating the train dataloader of corresponding dataset.
+            valid_dataloader (BaseDataLoader): Indicating the valid dataloader of corresponding dataset.
+            test_dataloader (BaseDataLoader): Indicating the test dataloader of corresponding dataset.
+            vocab (dict): Indicating the vocabulary.
+            side_data (dict): Indicating the side data.
+            restore_system (bool, optional): Indicating if we store system after training. Defaults to False.
+            interact (bool, optional): Indicating if we interact with system. Defaults to False.
+            debug (bool, optional): Indicating if we train in debug mode. Defaults to False.
+
+        """
+        super(InspiredSystem, self).__init__(opt, train_dataloader, valid_dataloader,
+                                             test_dataloader, vocab, side_data, restore_system, interact, debug)
+
+        if hasattr(self, 'conv_model'):
+            self.ind2tok = vocab['conv']['ind2tok']
+            self.end_token_idx = vocab['conv']['end']
+        if hasattr(self, 'rec_model'):
+            self.item_ids = side_data['rec']['item_entity_ids']
+            self.id2entity = vocab['rec']['id2entity']
+
+        if hasattr(self, 'rec_model'):
+            self.rec_optim_opt = self.opt['rec']
+            self.rec_epoch = self.rec_optim_opt['epoch']
+            self.rec_batch_size = self.rec_optim_opt['batch_size']
+
+        if hasattr(self, 'conv_model'):
+            self.conv_optim_opt = self.opt['conv']
+            self.conv_epoch = self.conv_optim_opt['epoch']
+            self.conv_batch_size = self.conv_optim_opt['batch_size']
+            if self.conv_optim_opt.get('lr_scheduler', None) and 'Transformers' in self.conv_optim_opt['lr_scheduler'][
+                'name']:
+                batch_num = 0
+                for _ in self.train_dataloader['conv'].get_conv_data(batch_size=self.conv_batch_size, shuffle=False):
+                    batch_num += 1
+                conv_training_steps = self.conv_epoch * floor(batch_num / self.conv_optim_opt.get('update_freq', 1))
+                self.conv_optim_opt['lr_scheduler']['training_steps'] = conv_training_steps
+
+        self.language = dataset_language_map[self.opt['dataset']]
+
+    def rec_evaluate(self, rec_predict, item_label):
+        rec_predict = rec_predict.cpu()
+        rec_predict = rec_predict[:, self.item_ids]
+        _, rec_ranks = torch.topk(rec_predict, 50, dim=-1)
+        rec_ranks = rec_ranks.tolist()
+        item_label = item_label.tolist()
+        for rec_rank, item in zip(rec_ranks, item_label):
+            item = self.item_ids.index(item)
+            self.evaluator.rec_evaluate(rec_rank, item)
+
+    def conv_evaluate(self, prediction, response):
+        """
+        Args:
+            prediction: torch.LongTensor, shape=(bs, response_truncate-1)
+            response: (torch.LongTensor, torch.LongTensor), shape=((bs, response_truncate), (bs, response_truncate))
+
+            the first token in response is <|endoftext|>,  it is not in prediction
+        """
+        prediction = prediction.tolist()
+        response = response.tolist()
+        for p, r in zip(prediction, response):
+            p_str = ind2txt(p, self.ind2tok, self.end_token_idx)
+            r_str = ind2txt(r[1:], self.ind2tok, self.end_token_idx)
+            self.evaluator.gen_evaluate(p_str, [r_str])
+
+    def step(self, batch, stage, mode):
+        """
+        stage: ['policy', 'rec', 'conv']
+        mode: ['train', 'val', 'test]
+        """
+        batch = [ele.to(self.device) for ele in batch]
+        if stage == 'rec':
+            if mode == 'train':
+                self.rec_model.train()
+            else:
+                self.rec_model.eval()
+
+            rec_loss, rec_predict = self.rec_model.recommend(batch, mode)
+            if mode == "train":
+                self.backward(rec_loss)
+            else:
+                self.rec_evaluate(rec_predict, batch[-1])
+            rec_loss = rec_loss.item()
+            self.evaluator.optim_metrics.add("rec_loss",
+                                             AverageMetric(rec_loss))
+        elif stage == "conv":
+            if mode != "test":
+                # train + valid: need to compute ppl
+                gen_loss, pred = self.conv_model.converse(batch, mode)
+                if mode == 'train':
+                    self.conv_model.train()
+                    self.backward(gen_loss)
+                else:
+                    self.conv_model.eval()
+                    self.conv_evaluate(pred, batch[-1])
+                gen_loss = gen_loss.item()
+                self.evaluator.optim_metrics.add("gen_loss",
+                                                 AverageMetric(gen_loss))
+                self.evaluator.gen_metrics.add("ppl", PPLMetric(gen_loss))
+            else:
+                # generate response in conv_model.step
+                pred = self.conv_model.converse(batch, mode)
+                self.conv_evaluate(pred, batch[-1])
+        else:
+            raise
+
+    def train_recommender(self):
+        if hasattr(self.rec_model, 'bert'):
+            bert_param = list(self.rec_model.bert.named_parameters())
+            bert_param_name = ['bert.' + n for n, p in bert_param]
+        else:
+            bert_param = []
+            bert_param_name = []
+        other_param = [
+            name_param for name_param in self.rec_model.named_parameters()
+            if name_param[0] not in bert_param_name
+        ]
+        params = [{'params': [p for n, p in bert_param], 'lr': self.rec_optim_opt['lr_bert']},
+                  {'params': [p for n, p in other_param]}]
+        self.init_optim(self.rec_optim_opt, params)
+
+        for epoch in range(self.rec_epoch):
+            self.evaluator.reset_metrics()
+            logger.info(f'[Recommendation epoch {str(epoch)}]')
+            for batch in self.train_dataloader['rec'].get_rec_data(self.rec_batch_size,
+                                                                   shuffle=True):
+                self.step(batch, stage='rec', mode='train')
+            self.evaluator.report()
+            # val
+            with torch.no_grad():
+                self.evaluator.reset_metrics()
+                for batch in self.valid_dataloader['rec'].get_rec_data(
+                        self.rec_batch_size, shuffle=False):
+                    self.step(batch, stage='rec', mode='val')
+                self.evaluator.report()
+                # early stop
+                metric = self.evaluator.rec_metrics['hit@1'] + self.evaluator.rec_metrics['hit@50']
+                if self.early_stop(metric):
+                    break
+        # test
+        with torch.no_grad():
+            self.evaluator.reset_metrics()
+            for batch in self.test_dataloader['rec'].get_rec_data(self.rec_batch_size,
+                                                                  shuffle=False):
+                self.step(batch, stage='rec', mode='test')
+            self.evaluator.report()
+
+    def train_conversation(self):
+        self.init_optim(self.conv_optim_opt, self.conv_model.parameters())
+
+        for epoch in range(self.conv_epoch):
+            self.evaluator.reset_metrics()
+            logger.info(f'[Conversation epoch {str(epoch)}]')
+            for batch in self.train_dataloader['conv'].get_conv_data(
+                    batch_size=self.conv_batch_size, shuffle=True):
+                self.step(batch, stage='conv', mode='train')
+            self.evaluator.report()
+            # val
+            with torch.no_grad():
+                self.evaluator.reset_metrics()
+                for batch in self.valid_dataloader['conv'].get_conv_data(
+                        batch_size=self.conv_batch_size, shuffle=False):
+                    self.step((batch), stage='conv', mode='val')
+                self.evaluator.report()
+                # early stop
+                metric = self.evaluator.gen_metrics['ppl']
+                if self.early_stop(metric):
+                    break
+        # test
+        with torch.no_grad():
+            self.evaluator.reset_metrics()
+            for batch in self.test_dataloader['conv'].get_conv_data(
+                    batch_size=self.conv_batch_size, shuffle=False):
+                self.step((batch), stage='conv', mode='test')
+            self.evaluator.report()
+
+    def fit(self):
+        if hasattr(self, 'rec_model'):
+            self.train_recommender()
+        if hasattr(self, 'conv_model'):
+            self.train_conversation()
+
+    def interact(self):
+        pass

--- a/crslab/system/tgredial.py
+++ b/crslab/system/tgredial.py
@@ -25,7 +25,7 @@ class TGReDialSystem(BaseSystem):
     """This is the system for TGReDial model"""
 
     def __init__(self, opt, train_dataloader, valid_dataloader, test_dataloader, vocab, side_data, restore_system=False,
-                 interact=False, debug=False):
+                 interact=False, debug=False, tensorboard=False):
         """
 
         Args:
@@ -38,10 +38,11 @@ class TGReDialSystem(BaseSystem):
             restore_system (bool, optional): Indicating if we store system after training. Defaults to False.
             interact (bool, optional): Indicating if we interact with system. Defaults to False.
             debug (bool, optional): Indicating if we train in debug mode. Defaults to False.
+            tensorboard (bool, optional) Indicating if we monitor the training performance in tensorboard. Defaults to False. 
 
         """
         super(TGReDialSystem, self).__init__(opt, train_dataloader, valid_dataloader,
-                                             test_dataloader, vocab, side_data, restore_system, interact, debug)
+                                             test_dataloader, vocab, side_data, restore_system, interact, debug, tensorboard)
 
         if hasattr(self, 'conv_model'):
             self.ind2tok = vocab['conv']['ind2tok']
@@ -182,14 +183,14 @@ class TGReDialSystem(BaseSystem):
             for batch in self.train_dataloader['rec'].get_rec_data(self.rec_batch_size,
                                                                    shuffle=True):
                 self.step(batch, stage='rec', mode='train')
-            self.evaluator.report()
+            self.evaluator.report(epoch=epoch, mode='train')
             # val
             with torch.no_grad():
                 self.evaluator.reset_metrics()
                 for batch in self.valid_dataloader['rec'].get_rec_data(
                         self.rec_batch_size, shuffle=False):
                     self.step(batch, stage='rec', mode='val')
-                self.evaluator.report()
+                self.evaluator.report(epoch=epoch, mode='val')
                 # early stop
                 metric = self.evaluator.rec_metrics['hit@1'] + self.evaluator.rec_metrics['hit@50']
                 if self.early_stop(metric):
@@ -200,7 +201,7 @@ class TGReDialSystem(BaseSystem):
             for batch in self.test_dataloader['rec'].get_rec_data(self.rec_batch_size,
                                                                   shuffle=False):
                 self.step(batch, stage='rec', mode='test')
-            self.evaluator.report()
+            self.evaluator.report(mode='test')
 
     def train_conversation(self):
         self.init_optim(self.conv_optim_opt, self.conv_model.parameters())
@@ -211,14 +212,14 @@ class TGReDialSystem(BaseSystem):
             for batch in self.train_dataloader['conv'].get_conv_data(
                     batch_size=self.conv_batch_size, shuffle=True):
                 self.step(batch, stage='conv', mode='train')
-            self.evaluator.report()
+            self.evaluator.report(epoch=epoch, mode='train')
             # val
             with torch.no_grad():
                 self.evaluator.reset_metrics()
                 for batch in self.valid_dataloader['conv'].get_conv_data(
                         batch_size=self.conv_batch_size, shuffle=False):
                     self.step(batch, stage='conv', mode='val')
-                self.evaluator.report()
+                self.evaluator.report(epoch=epoch, mode='val')
                 # early stop
                 metric = self.evaluator.gen_metrics['ppl']
                 if self.early_stop(metric):
@@ -229,7 +230,7 @@ class TGReDialSystem(BaseSystem):
             for batch in self.test_dataloader['conv'].get_conv_data(
                     batch_size=self.conv_batch_size, shuffle=False):
                 self.step(batch, stage='conv', mode='test')
-            self.evaluator.report()
+            self.evaluator.report(mode='test')
 
     def train_policy(self):
         policy_params = list(self.policy_model.named_parameters())
@@ -256,14 +257,14 @@ class TGReDialSystem(BaseSystem):
             for batch in self.train_dataloader['policy'].get_policy_data(
                     self.policy_batch_size, shuffle=True):
                 self.step(batch, stage='policy', mode='train')
-            self.evaluator.report()
+            self.evaluator.report(epoch=epoch, mode='train')
             # val
             with torch.no_grad():
                 self.evaluator.reset_metrics()
                 for batch in self.valid_dataloader['policy'].get_policy_data(
                         self.policy_batch_size, shuffle=False):
                     self.step(batch, stage='policy', mode='val')
-                self.evaluator.report()
+                self.evaluator.report(epoch=epoch, mode='val')
                 # early stop
                 metric = self.evaluator.rec_metrics['hit@1'] + self.evaluator.rec_metrics['hit@50']
                 if self.early_stop(metric):
@@ -274,7 +275,7 @@ class TGReDialSystem(BaseSystem):
             for batch in self.test_dataloader['policy'].get_policy_data(
                     self.policy_batch_size, shuffle=False):
                 self.step(batch, stage='policy', mode='test')
-            self.evaluator.report()
+            self.evaluator.report(mode='test')
 
     def fit(self):
         if hasattr(self, 'rec_model'):

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ nltk~=3.4.4
 requests~=2.25.1
 scikit-learn~=0.24.0
 fuzzywuzzy~=0.18.0
+tensorborad~=2.4.1

--- a/run_crslab.py
+++ b/run_crslab.py
@@ -33,10 +33,12 @@ if __name__ == '__main__':
                         help='use valid dataset to debug your system')
     parser.add_argument('-i', '--interact', action='store_true',
                         help='interact with your system instead of training')
+    parser.add_argument('-tb', '--tensorboard', action='store_true',
+                        help='enable tensorboard to monitor train performance')
     args, _ = parser.parse_known_args()
     config = Config(args.config, args.gpu, args.debug)
 
     from crslab.quick_start import run_crslab
 
     run_crslab(config, args.save_data, args.restore_data, args.save_system, args.restore_system, args.interact,
-               args.debug)
+               args.debug, args.tensorboard)

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ install_requires = [
     'requests~=2.25.1',
     'scikit-learn~=0.24.0',
     'fuzzywuzzy~=0.18.0',
+    'tensorborad~=2.4.1',
 ]
 
 classifiers = [


### PR DESCRIPTION
## Inspired
加入了 Inspired 论文中提出的模型，复现的部分包括：
* 对话部分
  * 针对`Seeker`和`Recommender`分开训练和推理的`GPT2`模型
  * 序列交叉损失函数
* 推荐部分
  * BERT 模型

没有复现的部分包括：
* 由于数据集限制，没有加入策略标签 token
* 缺少情感监督标签，没有训练情感分析模型
* 没有在`ReDial`等数据集上进行预训练

参数目前参考原文设置，但因为没有预训练以及策略标签，因此没能复现出结果，参数有待调整。

修复了`inspired`和`tgredial`的硬编码问题。

## tensorboard
向`StandardEvaluator`、`RecEvaluator`、`ConvEvaluator`加入了`tensorboard`，可以按`rec_metrics`、`conv_metrics`、`optim_metrics`分别描绘`train`和`valid`模式下的性能变化曲线。加入了命令行开关选项。

![](https://raw.githubusercontent.com/ToheartZhang/img-repo/main/%E5%B1%8F%E5%B9%95%E6%88%AA%E5%9B%BE%202021-03-23%20084552.png?token=AGDRJJM46HKAY4VTI5XWN2LALFNA4)

![](https://raw.githubusercontent.com/ToheartZhang/img-repo/main/%E5%B1%8F%E5%B9%95%E6%88%AA%E5%9B%BE%202021-03-23%20084520.png?token=AGDRJJIEG3AYMUAIGJWIU3DALFNAW)

