### PR TITLE
FEA: add model freezing for KBRD recommender module 

### DIFF
--- a/crslab/model/crs/kbrd/kbrd.py
+++ b/crslab/model/crs/kbrd/kbrd.py
@@ -308,3 +308,9 @@ class KBRDModel(BaseModel):
             return self.converse(batch, mode)
         if stage == "rec":
             return self.recommend(batch, mode)
+
+    def freeze_parameters(self):
+        freeze_models = [self.kg_encoder, self.kg_attn, self.rec_bias]
+        for model in freeze_models:
+            for p in model.parameters():
+                p.requires_grad = False

--- a/crslab/system/kbrd.py
+++ b/crslab/system/kbrd.py
@@ -7,6 +7,7 @@
 # @Time    :   2021/1/3
 # @Author  :   Xiaolei Wang
 # @email   :   wxl1999@foxmail.com
+import os
 
 import torch
 from loguru import logger
@@ -130,6 +131,10 @@ class KBRDSystem(BaseSystem):
             self.evaluator.report(mode='test')
 
     def train_conversation(self):
+        if os.environ["CUDA_VISIBLE_DEVICES"] == '-1':
+            self.model.freeze_parameters()
+        else:
+            self.model.module.freeze_parameters()
         self.init_optim(self.conv_optim_opt, self.model.parameters())
 
         for epoch in range(self.conv_epoch):


### PR DESCRIPTION
Fix #47 
---
- Add model freezing for KBRD
- Freeze KBRD recommendation module while training the conversation module 
- Able to freeze in DP mode and standard mode

