### PR TITLE
FIX：Bugs in split tokens

### DIFF
--- a/crslab/data/dataset/redial/resources.py
+++ b/crslab/data/dataset/redial/resources.py
@@ -53,7 +53,7 @@ resources = {
             '15661f1cb126210a09e30228e9477cf57bbec42140d2b1029cc50489beff4eb8',
         ),
         'special_token_idx': {
-            'pad': 0,
+            'pad': -100,
             'start': 1,
             'end': 2,
             'unk': 3,

--- a/crslab/evaluator/conv.py
+++ b/crslab/evaluator/conv.py
@@ -63,7 +63,9 @@ class ConvEvaluator(BaseEvaluator):
 
             for k in range(1, 5):
                 self.gen_metrics.add(f"bleu@{k}", BleuMetric.compute(hyp, refs, k))
-                for token in ngrams(hyp, k):
+                # split sentence to tokens here
+                hyp_token = hyp.split()
+                for token in ngrams(hyp_token, k):
                     self.dist_set[f"dist@{k}"].add(token)
             self.dist_cnt += 1
 

--- a/crslab/model/__init__.py
+++ b/crslab/model/__init__.py
@@ -56,7 +56,10 @@ def get_model(config, model_name, device, vocab, side_data=None):
                 if model_name == 'PMI' or model_name == 'KBRD':
                     logger.info(f'[PMI/KBRD model does not support multi GPUs yet, using single GPU now]')
                     return model.to(device)
-            return torch.nn.DataParallel(model, device_ids=config["gpu"])
+                else:
+                    return torch.nn.DataParallel(model, device_ids=config["gpu"])
+            else:
+                return model.to(device)
 
     else:
         raise NotImplementedError('Model [{}] has not been implemented'.format(model_name))


### PR DESCRIPTION
1.  The padding labels are set to -100
2.  Adding a simple split function to get the correct tokens instead of characters.